### PR TITLE
Update splash screen bg image scss

### DIFF
--- a/src/app/welcome-panel/welcome-panel.component.scss
+++ b/src/app/welcome-panel/welcome-panel.component.scss
@@ -7,7 +7,7 @@
     justify-content: center;
     align-items:flex-end;
     background: rgb(121, 121, 121);
-    background-image: url("../../assets/images/welcome.jpg");
+    background-image: url("/assets/images/welcome.jpg");
     background-blend-mode: darken;
     background-size: cover;
     background-position: center;


### PR DESCRIPTION
- Updated splash screen's scss for the background image to work both locally and theoretically in the build.
  - NOTE: Can now use absolute path for background image scss property now that website is not hosted in a directory (eg. cssa.github.io/cssa-website is now cssa.github.io). While using a relative path worked for building previously, it would cause 404 Not Found issues when run locally using ng serve for some reason.